### PR TITLE
Cron-job improvements and directory change

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,4 +67,7 @@ SVC_KB_ENABLE_PROCESSING=True # defaults to True
 SVC_KB_ENABLE_STORING=True # defaults to True
 
 # Cronjob schedule for running the knowledge base scraper, in cron format. Defaults to once a month.
-CRON_SCHEDULE="* * 1 * *"
+CRON_WIKIPEDIA_SCRAPE="* * 1 * *"
+
+# for future use, cronjob schedule for running the knowledge base processing, in cron format.
+CRON_WIKIPEDIA_RUN=

--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ To start the docker container: `docker compose up -d`
 * Wikipedia; ensure you `mkdir wikipedia` within the `./content/` folder and drop your files there.
 
 ### Cronjob Setup (Knowledge base links and sources update)
-IMPORTANT: For knowledge base scraping cronjob to run, you require a `mkdir content_Storage` within the `./content`
-folder
+IMPORTANT: For knowledge base scraping cronjob to run, you require a `mkdir wikipedia` within the `./content`
+folder, if not already made
 
 Instead of using the crontab, we are using the fastapi-crons library to control cronjobs through our
 fastapi server, with cronjob timings configurable in main.py. Cronjobs automatically run on server start.

--- a/main.py
+++ b/main.py
@@ -46,7 +46,7 @@ app.include_router(endpoints, prefix=KNOWLEDGE_BASE, tags=["Knowledge (Indexing 
 app.include_router(db_endpoints, prefix="/database", tags=["Database Interaction"])
 
 # Cronjob to check for new wiki dumps every set amount of time (in ENV file), currently defaulted to once a month:
-@crons.cron(os.getenv("CRON_SCHEDULE", "* * 1 * *"), name="run_knowledge_base_scraper")
+@crons.cron(os.getenv("CRON_WIKIPEDIA_SCRAPE", "* * 1 * *"), name="run_knowledge_base_scraper")
 def run_knowledge_base_scraper():
     """Cronjob that runs the knowledge base scraper to update new knowledge base dumps/files"""
     kb_scraper_main()

--- a/services/content_scraper/base_cronjob.py
+++ b/services/content_scraper/base_cronjob.py
@@ -37,7 +37,7 @@ from bs4 import BeautifulSoup
 from services.database.run_history_service import RunHistoryService
 from services.knowledge.models import RunStatus
 
-DOWNLOAD_DIRECTORY = "content/content_storage"
+DOWNLOAD_DIRECTORY = "content/wikipedia"
 
 # Enwiki dump RSS Feed URLs
 BASE_ENWIKI_INDEX_URL = (
@@ -65,6 +65,11 @@ def wiki_download_latest_dump(wiki_dump_content_url, wiki_dump_index_url):
 
     logger.info("============Downloading latest dump...============")
 
+    # ensure download directory exists
+    if not os.path.exists(DOWNLOAD_DIRECTORY):
+        os.makedirs(DOWNLOAD_DIRECTORY)
+        logger.info("Created download directory at %s", DOWNLOAD_DIRECTORY)
+
     list_of_links = wiki_list_maker(wiki_dump_content_url, wiki_dump_index_url)
     logger.info("List of download links retrieved: %s", list_of_links)
 
@@ -79,13 +84,17 @@ def wiki_download_latest_dump(wiki_dump_content_url, wiki_dump_index_url):
         filename = final_url.split("/")[-1]
         logger.info("Extracted filename: %s", filename)
 
+        downloading_file_name = filename.replace(".bz2", ".partial_download")
+        downloading_file_path = f"{DOWNLOAD_DIRECTORY}/{downloading_file_name}"
+
         response = requests.get(final_url, stream = True, verify=ENABLE_SSL_VERIFICATION,
                                 timeout=30)
         if response.status_code == 200:
-            with open(f"{DOWNLOAD_DIRECTORY}/{filename}", "wb") as f:
+            with open(f"{DOWNLOAD_DIRECTORY}/{downloading_file_name}", "wb") as f:
                 logger.info("Saving to %s/%s...", DOWNLOAD_DIRECTORY, filename)
                 for chunk in response.iter_content(chunk_size=8192):
                     f.write(chunk)
+            os.rename(downloading_file_path, f"{DOWNLOAD_DIRECTORY}/{filename}")
             logger.info("Successfully downloaded %s to %s, launching checksum verification...",
                         filename, DOWNLOAD_DIRECTORY)
             wiki_checksum_verification_hash_extractor(filename)

--- a/services/knowledge/wikipedia/wikipedia.py
+++ b/services/knowledge/wikipedia/wikipedia.py
@@ -303,7 +303,7 @@ class WikipediaKnowledgeService(KnowledgeService):
         for node in sorted(self._content_folder_path.rglob("*.txt.bz2")):
             if not node.is_file():
                 continue
-            if node.suffix == PROGRESS_SUFFIX:
+            if node.suffix == PROGRESS_SUFFIX or node.name.endswith(".partial_download"):
                 continue  # Skip progress files
             # Use fullmatch to ensure entire filename matches (excludes :Zone.Identifier files)
             match = INDEX_FILENAME.fullmatch(node.name)


### PR DESCRIPTION
Closes #139 

- .partial suffix while file is being downloaded (by the cronjob)
- Downloaded files are redirected to content/wikipedia, instead of content/content_storage. Done to avoid having to manually drag and drop files into correct directory when beginning a run
- Ingestion process will ignore all files that are partially downloaded to avoid bad data
- Cronjob env vars reconfigured

Example of partially downloaded file: 
<img width="595" height="38" alt="image" src="https://github.com/user-attachments/assets/d1d976f9-eeed-4a1c-ae10-33bb2d39d5d6" />
