### PR TITLE
fix: target self-hosted runner with custom ssc-dto label

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -13,7 +13,7 @@ env:
 
 jobs:
   build-cpu:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ssc-dto]
     permissions:
       contents: read
       packages: write
@@ -62,7 +62,7 @@ jobs:
 
   # Build for h100/h200 series
   build-cuda-h100-h200:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ssc-dto]
     permissions:
       contents: read
       packages: write
@@ -116,7 +116,7 @@ jobs:
 
   # Build for l40 series
   build-cuda-l40:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ssc-dto]
     permissions:
       contents: read
       packages: write


### PR DESCRIPTION
Generic 'self-hosted' label matched any runner with repo access (including a stale runner from the previous org), causing builds to run on the wrong machine. Scope docker.yml jobs to a custom 'ssc-dto' label so only the intended org runner picks them up.