### PR TITLE
Add source selector to EKH dummy UI

### DIFF
--- a/router/frontend/index.html
+++ b/router/frontend/index.html
@@ -42,6 +42,11 @@
 <body>
     <h1>Enterprise Knowledge Hub Endpoint test</h1>
     <form id="searchForm">
+        <label for="source">Source:</label>
+        <select id="source" style="margin-right:0.5em;">
+            <option value="wikipedia">Wikipedia</option>
+            <option value="tbs-policies">TBS Policies</option>
+        </select>
         <input type="text" id="query" placeholder="Please enter your search query..." required />
         <label for="limit" style="margin-left:0.5em;">Results: <span id="limitValue">5</span></label>
         <input type="range" id="limit" name="limit" min="1" max="20" value="5" style="vertical-align:middle; margin-left:0.5em;" />
@@ -57,13 +62,14 @@
 
         document.getElementById('searchForm').addEventListener('submit', async function (e) {
             e.preventDefault();
+            const source = document.getElementById('source').value;
             const query = document.getElementById('query').value;
             const limit = document.getElementById('limit').value;
             const resultsDiv = document.getElementById('results');
             resultsDiv.innerHTML = 'Searching...';
 
             try {
-                const response = await fetch('/database/search?query=' + encodeURIComponent(query) + '&limit=' + encodeURIComponent(limit), {
+                const response = await fetch('/database/' + encodeURIComponent(source) + '/search?query=' + encodeURIComponent(query) + '&limit=' + encodeURIComponent(limit), {
                     method: 'GET',
                     headers: { 'Accept': 'application/json' }
                 });


### PR DESCRIPTION
Adds a source selector so dummy UI can build full search queries that do not 404

<img width="1843" height="825" alt="image" src="https://github.com/user-attachments/assets/fcb8136c-1388-4978-a685-f5e47d1cb2a0" />


Notice the URL missing a source from before, resulting in a 404
<img width="586" height="53" alt="image" src="https://github.com/user-attachments/assets/b908696c-b72d-400e-b816-8cf624b7784e" />

Notice the URL now including a source, resulting in a 200
<img width="619" height="52" alt="image" src="https://github.com/user-attachments/assets/e081a924-c6f1-40f5-a853-aa0a09cdd8bc" />
