### PR TITLE
Add Ingestion Metrics

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -72,6 +72,7 @@ SVC_KB_ENABLE_STORING=True # defaults to True
 SVC_KB_PROGRESS_METRICS_ENABLED=False # defaults to False; updates metadata on phase start rows while running
 SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS=500 # defaults to 500; update progress after this many newly completed items
 SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS=2.0 # defaults to 2.0; update progress at least this often
+# Metrics are updated if either of the above two conditions are met.
 
 # Cronjob schedule for running the knowledge base scraper, in cron format. Defaults to once a month.
 CRON_WIKIPEDIA_SCRAPE="* * 1 * *"

--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,9 @@ REQUESTS_CA_BUNDLE=/etc/ssl/certs/ca-certificates.crt
 SVC_KB_ENABLE_INGESTION=True # defaults to True
 SVC_KB_ENABLE_PROCESSING=True # defaults to True
 SVC_KB_ENABLE_STORING=True # defaults to True
+SVC_KB_PROGRESS_METRICS_ENABLED=False # defaults to False; updates metadata on phase start rows while running
+SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS=500 # defaults to 500; update progress after this many newly completed items
+SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS=2.0 # defaults to 2.0; update progress at least this often
 
 # Cronjob schedule for running the knowledge base scraper, in cron format. Defaults to once a month.
 CRON_WIKIPEDIA_SCRAPE="* * 1 * *"

--- a/repository/run_history.py
+++ b/repository/run_history.py
@@ -33,3 +33,10 @@ class RunHistoryRepository(BaseRepository):
                 .get_or_none())
 
         return query
+
+    def update_metadata(self, row_id: int, metadata: dict | None) -> bool:
+        """Update metadata for a specific run_history row."""
+        query = (self.model
+                 .update(metadata=metadata)
+                 .where(self.model.id == row_id))
+        return query.execute() > 0

--- a/services/database/run_history_service.py
+++ b/services/database/run_history_service.py
@@ -54,3 +54,7 @@ class RunHistoryService():
     def select_first_instance_of_run_id(self, run_id: int) -> RunHistory | None:
         """Get the first record with run_id"""
         return self._repository.select_first_instance_of_run_id(run_id)
+
+    def update_history_table_log(self, row_id: int, metadata: dict | None) -> bool:
+        """Update metadata for an existing run_history row."""
+        return self._repository.update_metadata(row_id=row_id, metadata=metadata)

--- a/services/knowledge/base.py
+++ b/services/knowledge/base.py
@@ -138,24 +138,6 @@ class KnowledgeService(ABC):
             self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                           RunStatus.RUN_ENDED, None, datetime.now())
 
-    def _insert_start_log(self, run_status: RunStatus, stage: str,
-                                stage_start: float, total: int | None = None) -> int:
-        """Insert start status row and return the created run_history row id."""
-        metadata = self._progress_metrics.start_stage(
-            stage=stage,
-            stage_start=stage_start,
-            total=total,
-        )
-
-        row = self.run_history_service.insert_history_table_log(
-            self._run_id,
-            self.service_name,
-            run_status,
-            metadata,
-            datetime.now(),
-        )
-        return row.id
-
     @abstractmethod
     def _get_run_id(self) -> int:
         """Get a unique id for run"""
@@ -203,8 +185,8 @@ class KnowledgeService(ABC):
         """Ingest data into the knowledge base."""
         self.logger.info("Ingesting data into the knowledge base. (%s)", self.service_name)
         start = time.perf_counter()
-        ingest_started_row_id = self._insert_start_log(
-            RunStatus.INGESTION_STARTED, "ingest", start, total=None
+        ingest_started_row_id = self._progress_metrics.insert_start_log(
+            RunStatus.INGESTION_STARTED, "ingest", self._run_id, self.service_name, start, total=None
         )
         count = 0
         try:
@@ -263,8 +245,8 @@ class KnowledgeService(ABC):
 
         self.logger.info("Processing ingested data from queue: %s. (%s)", self._ingest_queue_name(), self.service_name)
         start = time.perf_counter()
-        processing_started_row_id = self._insert_start_log(
-            RunStatus.PROCESSING_STARTED, "process", start, total=None
+        processing_started_row_id = self._progress_metrics.insert_start_log(
+            RunStatus.PROCESSING_STARTED, "process", self._run_id, self.service_name, start, total=None
         )
         count = 0
 
@@ -338,8 +320,8 @@ class KnowledgeService(ABC):
         self.logger.info("Storing processed data from queue: %s. (%s)", self._processed_queue_name(),
                                                                         self.service_name)
         start = time.perf_counter()
-        storing_started_row_id = self._insert_start_log(
-            RunStatus.STORING_STARTED, "store", start, total=None
+        storing_started_row_id = self._progress_metrics.insert_start_log(
+            RunStatus.STORING_STARTED, "store", self._run_id, self.service_name, start, total=None
         )
         count = 0
 

--- a/services/knowledge/base.py
+++ b/services/knowledge/base.py
@@ -14,6 +14,7 @@ from services.database.kb_source_registry_service import KbSourceRegistryService
 from services.database.run_history_service import RunHistoryService
 from services.knowledge.models import KnowledgeItem
 from services.knowledge.models import RunStatus
+from services.knowledge.metrics import ProgressMetricsTracker
 from services.queue.queue_worker import QueueWorker
 from services.queue.queue_service import QueueService
 
@@ -31,18 +32,14 @@ class KnowledgeService(ABC):
     _poll_interval: float = 0.5  # seconds to wait before retrying empty queue
     _executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=3)
     _futures: list[Future] = field(default_factory=list)
-    _progress_metrics_enabled: bool = field(default=False, init=False)
-    _progress_update_every_n_items: int = field(default=500, init=False)
-    _progress_update_every_seconds: float = field(default=2.0, init=False)
-    _progress_state: dict[str, dict[str, float]] = field(default_factory=dict, init=False)
+    _progress_metrics: ProgressMetricsTracker = field(
+        default_factory=ProgressMetricsTracker,
+        init=False,
+    )
 
     def __post_init__(self) -> None:
         self._source_registry_service = KbSourceRegistryService()
-        self._progress_metrics_enabled = os.getenv(
-            "SVC_KB_PROGRESS_METRICS_ENABLED", "false"
-        ).lower() in ("1", "true", "yes")
-        self._progress_update_every_n_items = int(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS", "500"))
-        self._progress_update_every_seconds = float(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS", "2.0"))
+        self._progress_metrics = ProgressMetricsTracker()
 
     @abstractmethod
     def get_query_instruction(self) -> str:
@@ -141,38 +138,14 @@ class KnowledgeService(ABC):
             self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                           RunStatus.RUN_ENDED, None, datetime.now())
 
-    def _build_progress_metadata(self, stage: str, status: str, completed: int,
-                                 total: int | None, stage_start: float,
-                                 now_perf: float | None = None) -> dict[str, object]:
-        """Build progress metadata payload for a running stage."""
-        if now_perf is None:
-            now_perf = time.perf_counter()
-        elapsed_seconds = max(0.0, now_perf - stage_start)
-        throughput = completed / elapsed_seconds if elapsed_seconds > 0 else 0.0
-
-        return {
-            "stage": stage,
-            "status": status,
-            "completed": completed,
-            "total": total,
-            "throughput": throughput,
-            "elapsed_seconds": elapsed_seconds,
-            "updated_at": datetime.now().isoformat(),
-        }
-
     def _insert_start_log(self, run_status: RunStatus, stage: str,
                                 stage_start: float, total: int | None = None) -> int:
         """Insert start status row and return the created run_history row id."""
-        metadata = None
-        if self._progress_metrics_enabled:
-            metadata = self._build_progress_metadata(
-                stage=stage,
-                status="running",
-                completed=0,
-                total=total,
-                stage_start=stage_start,
-                now_perf=stage_start,
-            )
+        metadata = self._progress_metrics.start_stage(
+            stage=stage,
+            stage_start=stage_start,
+            total=total,
+        )
 
         row = self.run_history_service.insert_history_table_log(
             self._run_id,
@@ -181,44 +154,26 @@ class KnowledgeService(ABC):
             metadata,
             datetime.now(),
         )
-        self._progress_state[stage] = {"last_count": 0.0, "last_update": stage_start}
         return row.id
 
     def _update_progress(self, row_id: int, stage: str, completed: int,
                                      stage_start: float, total: int | None = None,
                                      stage_status: str = "running", force: bool = False) -> None:
         """Update progress metadata for a stage start row using throttling."""
-        if not self._progress_metrics_enabled:
-            return
-
-        now_perf = time.perf_counter()
-        state = self._progress_state.setdefault(
-            stage, {"last_count": 0.0, "last_update": stage_start}
-        )
-        count_delta = completed - int(state["last_count"])
-        time_delta = now_perf - state["last_update"]
-
-        should_update = force or (
-            count_delta >= self._progress_update_every_n_items
-            or time_delta >= self._progress_update_every_seconds
-        )
-        if not should_update:
-            return
-
-        metadata = self._build_progress_metadata(
+        metadata = self._progress_metrics.maybe_progress_metadata(
             stage=stage,
-            status=stage_status,
             completed=completed,
-            total=total,
             stage_start=stage_start,
-            now_perf=now_perf,
+            total=total,
+            stage_status=stage_status,
+            force=force,
         )
+        if metadata is None:
+            return
         self.run_history_service.update_history_table_log(
             row_id=row_id,
             metadata=metadata,
         )
-        state["last_count"] = float(completed)
-        state["last_update"] = now_perf
 
     @abstractmethod
     def _get_run_id(self) -> int:

--- a/services/knowledge/base.py
+++ b/services/knowledge/base.py
@@ -39,7 +39,7 @@ class KnowledgeService(ABC):
 
     def __post_init__(self) -> None:
         self._source_registry_service = KbSourceRegistryService()
-        self._progress_metrics = ProgressMetricsTracker()
+        self._progress_metrics = ProgressMetricsTracker(self.run_history_service)
 
     @abstractmethod
     def get_query_instruction(self) -> str:
@@ -156,25 +156,6 @@ class KnowledgeService(ABC):
         )
         return row.id
 
-    def _update_progress(self, row_id: int, stage: str, completed: int,
-                                     stage_start: float, total: int | None = None,
-                                     stage_status: str = "running", force: bool = False) -> None:
-        """Update progress metadata for a stage start row using throttling."""
-        metadata = self._progress_metrics.maybe_progress_metadata(
-            stage=stage,
-            completed=completed,
-            stage_start=stage_start,
-            total=total,
-            stage_status=stage_status,
-            force=force,
-        )
-        if metadata is None:
-            return
-        self.run_history_service.update_history_table_log(
-            row_id=row_id,
-            metadata=metadata,
-        )
-
     @abstractmethod
     def _get_run_id(self) -> int:
         """Get a unique id for run"""
@@ -232,7 +213,7 @@ class KnowledgeService(ABC):
                     break
                 self.emit_fetched_item(item)
                 count += 1
-                self._update_progress(
+                self._progress_metrics.update_progress(
                     row_id=ingest_started_row_id,
                     stage="ingest",
                     completed=count,
@@ -247,7 +228,7 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_ingest for: %s",
                                 self.service_name)
-        self._update_progress(
+        self._progress_metrics.update_progress(
             row_id=ingest_started_row_id,
             stage="ingest",
             completed=count,
@@ -300,7 +281,7 @@ class KnowledgeService(ABC):
                 service_name=self.service_name,
                 handler=self.process_handler,
                 should_exit=self.process_should_exit,
-                on_message=lambda current_count: self._update_progress(
+                on_message=lambda current_count: self._progress_metrics.update_progress(
                     row_id=processing_started_row_id,
                     stage="process",
                     completed=current_count,
@@ -319,7 +300,7 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_process for queue: %s. (%s)",
                                 self._ingest_queue_name(), self.service_name)
-        self._update_progress(
+        self._progress_metrics.update_progress(
             row_id=processing_started_row_id,
             stage="process",
             completed=count,
@@ -375,7 +356,7 @@ class KnowledgeService(ABC):
                 service_name=self.service_name,
                 handler=self.store_handler,
                 should_exit=self.store_should_exit,
-                on_message=lambda current_count: self._update_progress(
+                on_message=lambda current_count: self._progress_metrics.update_progress(
                     row_id=storing_started_row_id,
                     stage="store",
                     completed=current_count,
@@ -393,7 +374,7 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_store for queue: %s. (%s)",
                                                                     self._processed_queue_name(), self.service_name)
-        self._update_progress(
+        self._progress_metrics.update_progress(
             row_id=storing_started_row_id,
             stage="store",
             completed=count,

--- a/services/knowledge/base.py
+++ b/services/knowledge/base.py
@@ -33,7 +33,7 @@ class KnowledgeService(ABC):
     _executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=3)
     _futures: list[Future] = field(default_factory=list)
     _progress_metrics: ProgressMetricsTracker = field(
-        default_factory=ProgressMetricsTracker,
+        default=None,
         init=False,
     )
 

--- a/services/knowledge/base.py
+++ b/services/knowledge/base.py
@@ -8,6 +8,7 @@ from typing import Any
 import logging
 import threading
 from datetime import datetime
+import time
 
 from services.database.kb_source_registry_service import KbSourceRegistryService
 from services.database.run_history_service import RunHistoryService
@@ -30,9 +31,18 @@ class KnowledgeService(ABC):
     _poll_interval: float = 0.5  # seconds to wait before retrying empty queue
     _executor: ThreadPoolExecutor = ThreadPoolExecutor(max_workers=3)
     _futures: list[Future] = field(default_factory=list)
+    _progress_metrics_enabled: bool = field(default=False, init=False)
+    _progress_update_every_n_items: int = field(default=500, init=False)
+    _progress_update_every_seconds: float = field(default=2.0, init=False)
+    _progress_state: dict[str, dict[str, float]] = field(default_factory=dict, init=False)
 
     def __post_init__(self) -> None:
         self._source_registry_service = KbSourceRegistryService()
+        self._progress_metrics_enabled = os.getenv(
+            "SVC_KB_PROGRESS_METRICS_ENABLED", "false"
+        ).lower() in ("1", "true", "yes")
+        self._progress_update_every_n_items = int(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS", "500"))
+        self._progress_update_every_seconds = float(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS", "2.0"))
 
     @abstractmethod
     def get_query_instruction(self) -> str:
@@ -131,6 +141,85 @@ class KnowledgeService(ABC):
             self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                           RunStatus.RUN_ENDED, None, datetime.now())
 
+    def _build_progress_metadata(self, stage: str, status: str, completed: int,
+                                 total: int | None, stage_start: float,
+                                 now_perf: float | None = None) -> dict[str, object]:
+        """Build progress metadata payload for a running stage."""
+        if now_perf is None:
+            now_perf = time.perf_counter()
+        elapsed_seconds = max(0.0, now_perf - stage_start)
+        throughput = completed / elapsed_seconds if elapsed_seconds > 0 else 0.0
+
+        return {
+            "stage": stage,
+            "status": status,
+            "completed": completed,
+            "total": total,
+            "throughput": throughput,
+            "elapsed_seconds": elapsed_seconds,
+            "updated_at": datetime.now().isoformat(),
+        }
+
+    def _insert_start_log(self, run_status: RunStatus, stage: str,
+                                stage_start: float, total: int | None = None) -> int:
+        """Insert start status row and return the created run_history row id."""
+        metadata = None
+        if self._progress_metrics_enabled:
+            metadata = self._build_progress_metadata(
+                stage=stage,
+                status="running",
+                completed=0,
+                total=total,
+                stage_start=stage_start,
+                now_perf=stage_start,
+            )
+
+        row = self.run_history_service.insert_history_table_log(
+            self._run_id,
+            self.service_name,
+            run_status,
+            metadata,
+            datetime.now(),
+        )
+        self._progress_state[stage] = {"last_count": 0.0, "last_update": stage_start}
+        return row.id
+
+    def _update_progress(self, row_id: int, stage: str, completed: int,
+                                     stage_start: float, total: int | None = None,
+                                     stage_status: str = "running", force: bool = False) -> None:
+        """Update progress metadata for a stage start row using throttling."""
+        if not self._progress_metrics_enabled:
+            return
+
+        now_perf = time.perf_counter()
+        state = self._progress_state.setdefault(
+            stage, {"last_count": 0.0, "last_update": stage_start}
+        )
+        count_delta = completed - int(state["last_count"])
+        time_delta = now_perf - state["last_update"]
+
+        should_update = force or (
+            count_delta >= self._progress_update_every_n_items
+            or time_delta >= self._progress_update_every_seconds
+        )
+        if not should_update:
+            return
+
+        metadata = self._build_progress_metadata(
+            stage=stage,
+            status=stage_status,
+            completed=completed,
+            total=total,
+            stage_start=stage_start,
+            now_perf=now_perf,
+        )
+        self.run_history_service.update_history_table_log(
+            row_id=row_id,
+            metadata=metadata,
+        )
+        state["last_count"] = float(completed)
+        state["last_update"] = now_perf
+
     @abstractmethod
     def _get_run_id(self) -> int:
         """Get a unique id for run"""
@@ -177,9 +266,10 @@ class KnowledgeService(ABC):
     def ingest(self) -> None:
         """Ingest data into the knowledge base."""
         self.logger.info("Ingesting data into the knowledge base. (%s)", self.service_name)
-
-        self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
-                                                          RunStatus.INGESTION_STARTED, None, datetime.now())
+        start = time.perf_counter()
+        ingest_started_row_id = self._insert_start_log(
+            RunStatus.INGESTION_STARTED, "ingest", start, total=None
+        )
         count = 0
         try:
             for item in self.fetch_from_source():
@@ -187,6 +277,12 @@ class KnowledgeService(ABC):
                     break
                 self.emit_fetched_item(item)
                 count += 1
+                self._update_progress(
+                    row_id=ingest_started_row_id,
+                    stage="ingest",
+                    completed=count,
+                    stage_start=start,
+                )
         except Exception:
             self.logger.exception("Error during ingestion for %s", self.service_name)
 
@@ -196,6 +292,15 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_ingest for: %s",
                                 self.service_name)
+        self._update_progress(
+            row_id=ingest_started_row_id,
+            stage="ingest",
+            completed=count,
+            total=count,
+            stage_start=start,
+            stage_status="completed",
+            force=True,
+        )
         self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                               RunStatus.INGESTION_COMPLETED,
                                                               {"count": count,
@@ -221,8 +326,11 @@ class KnowledgeService(ABC):
         """Process ingested data. Keeps polling until producer is done and queue is empty."""
 
         self.logger.info("Processing ingested data from queue: %s. (%s)", self._ingest_queue_name(), self.service_name)
-        self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
-                                                              RunStatus.PROCESSING_STARTED, None, datetime.now())
+        start = time.perf_counter()
+        processing_started_row_id = self._insert_start_log(
+            RunStatus.PROCESSING_STARTED, "process", start, total=None
+        )
+        count = 0
 
         try:
             worker = QueueWorker(
@@ -236,7 +344,13 @@ class KnowledgeService(ABC):
                 queue_name=self._ingest_queue_name(),
                 service_name=self.service_name,
                 handler=self.process_handler,
-                should_exit=self.process_should_exit
+                should_exit=self.process_should_exit,
+                on_message=lambda current_count: self._update_progress(
+                    row_id=processing_started_row_id,
+                    stage="process",
+                    completed=current_count,
+                    stage_start=start,
+                ),
             )
 
             count = worker.message_count
@@ -250,7 +364,15 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_process for queue: %s. (%s)",
                                 self._ingest_queue_name(), self.service_name)
-
+        self._update_progress(
+            row_id=processing_started_row_id,
+            stage="process",
+            completed=count,
+            total=count,
+            stage_start=start,
+            stage_status="completed",
+            force=True,
+        )
 
         self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                               RunStatus.PROCESSING_COMPLETED,
@@ -279,8 +401,11 @@ class KnowledgeService(ABC):
         """
         self.logger.info("Storing processed data from queue: %s. (%s)", self._processed_queue_name(),
                                                                         self.service_name)
-        self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
-                                                          RunStatus.STORING_STARTED, None, datetime.now())
+        start = time.perf_counter()
+        storing_started_row_id = self._insert_start_log(
+            RunStatus.STORING_STARTED, "store", start, total=None
+        )
+        count = 0
 
         try:
             worker = QueueWorker(
@@ -294,7 +419,13 @@ class KnowledgeService(ABC):
                 queue_name=self._processed_queue_name(),
                 service_name=self.service_name,
                 handler=self.store_handler,
-                should_exit=self.store_should_exit
+                should_exit=self.store_should_exit,
+                on_message=lambda current_count: self._update_progress(
+                    row_id=storing_started_row_id,
+                    stage="store",
+                    completed=current_count,
+                    stage_start=start,
+                ),
             )
 
             count = worker.message_count
@@ -307,6 +438,15 @@ class KnowledgeService(ABC):
         except Exception:
             self.logger.exception("Error during finalize_store for queue: %s. (%s)",
                                                                     self._processed_queue_name(), self.service_name)
+        self._update_progress(
+            row_id=storing_started_row_id,
+            stage="store",
+            completed=count,
+            total=count,
+            stage_start=start,
+            stage_status="completed",
+            force=True,
+        )
 
         self.run_history_service.insert_history_table_log(self._run_id, self.service_name,
                                                               RunStatus.STORING_COMPLETED,

--- a/services/knowledge/metrics.py
+++ b/services/knowledge/metrics.py
@@ -23,7 +23,7 @@ class ProgressMetricsTracker:
     update_every_n_items: int = 500
     update_every_seconds: float = 2.0
     _state: dict[str, StageProgressState] = field(default_factory=dict)
-    _run_history_service: RunHistoryService
+    _run_history_service: RunHistoryService = field(init=False, default=None)  # type: ignore[assignment]
 
     def __init__(self, run_history_service: RunHistoryService) -> None:
         """Initialize tracker, defaulting to environment-derived config."""
@@ -55,39 +55,39 @@ class ProgressMetricsTracker:
     def update_progress(self, row_id: int, stage: str, completed: int,
                                          stage_start: float, total: int | None = None,
                                          stage_status: str = "running", force: bool = False) -> None:
-            """Update progress metadata for a stage start row using throttling."""
-            metadata = self.maybe_progress_metadata(
-                stage=stage,
-                completed=completed,
-                stage_start=stage_start,
-                total=total,
-                stage_status=stage_status,
-                force=force,
-            )
-            if metadata is None:
-                return
-            self._run_history_service.update_history_table_log(
-                row_id=row_id,
-                metadata=metadata,
-            )
+        """Update progress metadata for a stage start row using throttling."""
+        metadata = self.maybe_progress_metadata(
+            stage=stage,
+            completed=completed,
+            stage_start=stage_start,
+            total=total,
+            stage_status=stage_status,
+            force=force,
+        )
+        if metadata is None:
+            return
+        self._run_history_service.update_history_table_log(
+            row_id=row_id,
+            metadata=metadata,
+        )
 
     def insert_start_log(self, run_status: RunStatus, stage: str,
                          run_id: int, service_name: str, stage_start: float, total: int | None = None) -> int:
-            """Insert start status row and return the created run_history row id."""
-            metadata = self.start_stage(
-                stage=stage,
-                stage_start=stage_start,
-                total=total,
-            )
-    
-            row = self._run_history_service.insert_history_table_log(
-                run_id,
-                service_name,
-                run_status,
-                metadata,
-                datetime.now(),
-            )
-            return row.id
+        """Insert start status row and return the created run_history row id."""
+        metadata = self.start_stage(
+            stage=stage,
+            stage_start=stage_start,
+            total=total,
+        )
+
+        row = self._run_history_service.insert_history_table_log(
+            run_id,
+            service_name,
+            run_status,
+            metadata,
+            datetime.now(),
+        )
+        return row.id
 
     def build_progress_metadata(self, stage: str, status: str, completed: int, total: int | None, stage_start: float,
                                 now_perf: float | None = None) -> dict[str, object]:
@@ -108,7 +108,7 @@ class ProgressMetricsTracker:
             "updated_at": datetime.now().isoformat(),
         }
 
-    def maybe_progress_metadata(self, stage: str, completed: int, stage_start: float, total: int | None = None, 
+    def maybe_progress_metadata(self, stage: str, completed: int, stage_start: float, total: int | None = None,
                                 stage_status: str = "running", force: bool = False) -> dict[str, object] | None:
         """Return progress metadata for a stage, if an update is ready"""
         if not self.enabled:

--- a/services/knowledge/metrics.py
+++ b/services/knowledge/metrics.py
@@ -5,6 +5,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import datetime
 from services.database.run_history_service import RunHistoryService
+from services.knowledge.models import RunStatus
 
 @dataclass
 class StageProgressState:
@@ -69,6 +70,24 @@ class ProgressMetricsTracker:
                 row_id=row_id,
                 metadata=metadata,
             )
+
+    def insert_start_log(self, run_status: RunStatus, stage: str,
+                         run_id: int, service_name: str, stage_start: float, total: int | None = None) -> int:
+            """Insert start status row and return the created run_history row id."""
+            metadata = self.start_stage(
+                stage=stage,
+                stage_start=stage_start,
+                total=total,
+            )
+    
+            row = self._run_history_service.insert_history_table_log(
+                run_id,
+                service_name,
+                run_status,
+                metadata,
+                datetime.now(),
+            )
+            return row.id
 
     def build_progress_metadata(self, stage: str, status: str, completed: int, total: int | None, stage_start: float,
                                 now_perf: float | None = None) -> dict[str, object]:

--- a/services/knowledge/metrics.py
+++ b/services/knowledge/metrics.py
@@ -1,0 +1,102 @@
+"""Progress metric helpers shared by knowledge services."""
+
+import os
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass
+class StageProgressState:
+    """Per-stage state used for progress updates"""
+
+    last_count: float
+    last_update: float
+
+
+@dataclass
+class ProgressMetricsTracker:
+    """Build and throttle progress metadata updates for run history logs"""
+
+    enabled: bool = False
+    update_every_n_items: int = 500
+    update_every_seconds: float = 2.0
+    _state: dict[str, StageProgressState] = field(default_factory=dict)
+
+    def __init__(self) -> None:
+        """Initialize tracker, defaulting to environment-derived config."""
+        self.from_env()
+        self._state = {}
+
+    def from_env(self) -> None:
+        """Read tracker config from environment variables."""
+        self.enabled = os.getenv("SVC_KB_PROGRESS_METRICS_ENABLED", "false").lower() in ("1", "true", "yes")
+        self.update_every_n_items = int(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS", "500"))
+        self.update_every_seconds = float(os.getenv("SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS", "2.0"))
+
+    def start_stage(self, stage: str, stage_start: float, total: int | None = None) -> dict[str, object] | None:
+        """Initialize stage tracking and optionally return initial metadata"""
+        self._state[stage] = StageProgressState(last_count=0.0, last_update=stage_start)
+        if not self.enabled:
+            return None
+
+        return self.build_progress_metadata(
+            stage=stage,
+            status="running",
+            completed=0,
+            total=total,
+            stage_start=stage_start,
+            now_perf=stage_start,
+        )
+
+    def build_progress_metadata(self, stage: str, status: str, completed: int, total: int | None, stage_start: float,
+                                now_perf: float | None = None) -> dict[str, object]:
+        """Build progress metadata payload for a running stage"""
+        if now_perf is None:
+            now_perf = time.perf_counter()
+
+        elapsed_seconds = max(0.0, now_perf - stage_start)
+        throughput = completed / elapsed_seconds if elapsed_seconds > 0 else 0.0
+
+        return {
+            "stage": stage,
+            "status": status,
+            "completed": completed,
+            "total": total,
+            "throughput": throughput,
+            "elapsed_seconds": elapsed_seconds,
+            "updated_at": datetime.now().isoformat(),
+        }
+
+    def maybe_progress_metadata(self, stage: str, completed: int, stage_start: float, total: int | None = None, 
+                                stage_status: str = "running", force: bool = False) -> dict[str, object] | None:
+        """Return progress metadata for a stage, if an update is ready"""
+        if not self.enabled:
+            return None
+
+        now_perf = time.perf_counter()
+        state = self._state.setdefault(
+            stage,
+            StageProgressState(last_count=0.0, last_update=stage_start),
+        )
+        count_delta = completed - int(state.last_count)
+        time_delta = now_perf - state.last_update
+
+        should_update = force or (
+            count_delta >= self.update_every_n_items
+            or time_delta >= self.update_every_seconds
+        )
+        if not should_update:
+            return None
+
+        metadata = self.build_progress_metadata(
+            stage=stage,
+            status=stage_status,
+            completed=completed,
+            total=total,
+            stage_start=stage_start,
+            now_perf=now_perf,
+        )
+        state.last_count = float(completed)
+        state.last_update = now_perf
+        return metadata

--- a/services/knowledge/metrics.py
+++ b/services/knowledge/metrics.py
@@ -4,7 +4,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
-
+from services.database.run_history_service import RunHistoryService
 
 @dataclass
 class StageProgressState:
@@ -22,11 +22,13 @@ class ProgressMetricsTracker:
     update_every_n_items: int = 500
     update_every_seconds: float = 2.0
     _state: dict[str, StageProgressState] = field(default_factory=dict)
+    _run_history_service: RunHistoryService
 
-    def __init__(self) -> None:
+    def __init__(self, run_history_service: RunHistoryService) -> None:
         """Initialize tracker, defaulting to environment-derived config."""
         self.from_env()
         self._state = {}
+        self._run_history_service = run_history_service
 
     def from_env(self) -> None:
         """Read tracker config from environment variables."""
@@ -48,6 +50,25 @@ class ProgressMetricsTracker:
             stage_start=stage_start,
             now_perf=stage_start,
         )
+
+    def update_progress(self, row_id: int, stage: str, completed: int,
+                                         stage_start: float, total: int | None = None,
+                                         stage_status: str = "running", force: bool = False) -> None:
+            """Update progress metadata for a stage start row using throttling."""
+            metadata = self.maybe_progress_metadata(
+                stage=stage,
+                completed=completed,
+                stage_start=stage_start,
+                total=total,
+                stage_status=stage_status,
+                force=force,
+            )
+            if metadata is None:
+                return
+            self._run_history_service.update_history_table_log(
+                row_id=row_id,
+                metadata=metadata,
+            )
 
     def build_progress_metadata(self, stage: str, status: str, completed: int, total: int | None, stage_start: float,
                                 now_perf: float | None = None) -> dict[str, object]:

--- a/services/queue/queue_worker.py
+++ b/services/queue/queue_worker.py
@@ -22,7 +22,8 @@ class QueueWorker:
         self.poll_interval = poll_interval
         self.message_count = 0
 
-    def run(self, service_name: str, queue_name: str, handler: Callable[..., Any], should_exit: Callable[[bool], bool]):
+    def run(self, service_name: str, queue_name: str, handler: Callable[..., Any],
+            should_exit: Callable[[bool], bool], on_message: Callable[[int], None] | None = None):
         """
         Main function to poll from queues.
 
@@ -33,6 +34,7 @@ class QueueWorker:
         :type queue_name: str
         :param handler: callable function.  processes item
         :param should_exit: callable function. exit condition for loop
+        :param on_message: callable function. called after each message
         """
         while not self.stop_event.is_set():
             drained_any = False # to check if any messages read/drained this iteration
@@ -41,6 +43,8 @@ class QueueWorker:
                 for item, delivery_tag in self.queue_service.read(queue_name):
                     drained_any = True
                     self.message_count += 1
+                    if on_message is not None:
+                        on_message(self.message_count)
                     try:
                         if self.stop_event.is_set():
                             self.logger.info("Stop event is true. Stopping process: %s - %s", service_name, queue_name)

--- a/tests/ingestion/monitor_ingestion_progress.py
+++ b/tests/ingestion/monitor_ingestion_progress.py
@@ -188,6 +188,42 @@ def _fetch_database_volume_bytes(conn: psycopg.Connection) -> int | None:
     return int(value)
 
 
+def _iter_stage_progress_rows(rows: list[ProgressRow]) -> list[tuple[str, dict[str, Any]]]:
+    """Project run_history rows to stage names and normalized metadata dicts."""
+    projected: list[tuple[str, dict[str, Any]]] = []
+    for row in rows:
+        stage = START_STAGE_BY_STATUS.get(row.status)
+        if stage is None:
+            continue
+        projected.append((stage, row.metadata or {}))
+    return projected
+
+
+def _append_stage_progress_rows(
+    rows: list[ProgressRow],
+    output_path: Path,
+    experiment_name: str | None,
+    run_id: int,
+    service_name: str,
+    database_volume_bytes: int | None,
+) -> None:
+    """Append all stage progress rows for the current poll sample."""
+    for stage, metadata in _iter_stage_progress_rows(rows):
+        _append_csv_row(
+            output_path,
+            experiment_name,
+            run_id,
+            service_name,
+            stage,
+            metadata.get("status"),
+            metadata.get("completed"),
+            metadata.get("total"),
+            metadata.get("throughput"),
+            metadata.get("elapsed_seconds"),
+            database_volume_bytes,
+        )
+
+
 def _monitor_run_progress(
     run_id: int,
     service_name: str,
@@ -203,34 +239,15 @@ def _monitor_run_progress(
         while True:
             rows = _fetch_run_rows(conn, run_id, service_name)
             database_volume_bytes = _fetch_database_volume_bytes(conn)
-
             ended = any(row.status in (RUN_ENDED, RUN_STOPPED) for row in rows)
-
-            for row in rows:
-                stage = START_STAGE_BY_STATUS.get(row.status)
-                if stage is None:
-                    continue
-
-                metadata = row.metadata or {}
-                stage_status = metadata.get("status")
-                completed = metadata.get("completed")
-                total = metadata.get("total")
-                throughput = metadata.get("throughput")
-                elapsed_seconds = metadata.get("elapsed_seconds")
-
-                _append_csv_row(
-                    output_path,
-                    experiment_name,
-                    run_id,
-                    service_name,
-                    stage,
-                    stage_status,
-                    completed,
-                    total,
-                    throughput,
-                    elapsed_seconds,
-                    database_volume_bytes,
-                )
+            _append_stage_progress_rows(
+                rows=rows,
+                output_path=output_path,
+                experiment_name=experiment_name,
+                run_id=run_id,
+                service_name=service_name,
+                database_volume_bytes=database_volume_bytes,
+            )
 
             if ended:
                 print(f"Run {run_id} ended. CSV written to {output_path}")
@@ -257,9 +274,9 @@ def main() -> int:
 
     load_dotenv()
 
-    # Use the provided run_id or generate a (somewhat) random run_id. 
+    # Use the provided run_id or generate a (somewhat) random run_id.
     # This removes the need to handle searching for the correct run_id.
-    run_id = int(time.time()) & 0x7FFFFFFF
+    run_id = args.run_id if args.run_id is not None else int(time.time()) & 0x7FFFFFFF
 
     output_path = Path(args.output_csv) if args.output_csv else _build_default_output_path()
 

--- a/tests/ingestion/monitor_ingestion_progress.py
+++ b/tests/ingestion/monitor_ingestion_progress.py
@@ -1,0 +1,286 @@
+"""Start an ingestion run and stream stage progress metadata to CSV.
+
+Usage example:
+    uv run --env-file .env python tests/ingestion/monitor_ingestion_progress.py \
+        --service tbs-policies \
+        --api-base-url http://localhost:8000 \
+        --poll-interval 2.0 \
+        --timeout-seconds 7200
+
+    This will start a new run for the tbs-policies service,
+    and poll the run_history table every 2 seconds for up to a limit of 2 hours
+"""
+
+from __future__ import annotations
+
+import argparse
+import ast
+import csv
+import json
+import os
+import time
+from dataclasses import dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+from urllib.error import URLError
+from urllib.request import urlopen
+
+import psycopg
+from dotenv import load_dotenv
+
+# Constants for run_history status values and stage mapping
+RUN_ENDED = "Run Completed"
+RUN_STOPPED = "Run Manually Stopped"
+INGESTION_STARTED = "Ingestion Started"
+PROCESSING_STARTED = "Processing Started"
+STORING_STARTED = "Storing Started"
+
+START_STAGE_BY_STATUS = {
+    INGESTION_STARTED: "ingest",
+    PROCESSING_STARTED: "process",
+    STORING_STARTED: "store",
+}
+
+
+@dataclass
+class ProgressRow:
+    """Projected run_history row for CSV output."""
+    status: str
+    metadata: dict[str, Any] | None
+
+
+def _parse_metadata(raw: Any) -> dict[str, Any] | None:
+    """Parse run_history metadata."""
+    if raw is None:
+        return None
+    if isinstance(raw, dict):
+        return raw
+    if isinstance(raw, str):
+        text = raw.strip()
+        if not text:
+            return None
+        try:
+            value = json.loads(text)
+            if isinstance(value, dict):
+                return value
+        except json.JSONDecodeError:
+            pass
+        try:
+            value = ast.literal_eval(text)
+            if isinstance(value, dict):
+                return value
+        except (ValueError, SyntaxError):
+            pass
+    return None
+
+
+def _open_db_connection() -> psycopg.Connection:
+    """Open a PostgreSQL connection using the .env file variables."""
+    host = os.getenv("POSTGRES_HOST", "localhost")
+    port = int(os.getenv("POSTGRES_PORT", "5432"))
+    dbname = os.getenv("POSTGRES_DB", "rag")
+    user = os.getenv("POSTGRES_USER", "admin")
+    password = os.getenv("POSTGRES_PASSWORD", "admin")
+
+    return psycopg.connect(
+        host=host,
+        port=port,
+        dbname=dbname,
+        user=user,
+        password=password,
+    )
+
+
+def _fetch_run_rows(conn: psycopg.Connection, run_id: int, service_name: str) -> list[ProgressRow]:
+    """Fetch all run_history rows for a run."""
+    sql = (
+        "SELECT status, metadata "
+        "FROM run_history "
+        "WHERE run_id = %s AND service_name = %s "
+        "ORDER BY timestamp ASC"
+    )
+    with conn.cursor() as cur:
+        cur.execute(sql, (run_id, service_name))
+        rows = cur.fetchall()
+
+    result: list[ProgressRow] = []
+    for row in rows:
+        result.append(
+            ProgressRow(
+                status=row[0],
+                metadata=_parse_metadata(row[1]),
+            )
+        )
+    return result
+
+
+def _start_run(api_base_url: str, service: str, run_id: int) -> None:
+    """Call the run endpoint with a fixed run_id."""
+    url = f"{api_base_url.rstrip('/')}/knowledge/{service}/run?run_id={run_id}"
+    with urlopen(url, timeout=30) as response:  # nosec B310
+        _ = response.read()
+
+
+def _prepare_csv(path: Path) -> None:
+    """Create CSV parent directory and write header if missing."""
+    path.parent.mkdir(parents=True, exist_ok=True)
+    if path.exists():
+        return
+
+    with path.open("w", newline="", encoding="utf-8") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            [
+                "sample_time_utc",
+                "experiment_name",
+                "run_id",
+                "service_name",
+                "stage",
+                "stage_status",
+                "completed",
+                "total",
+                "throughput",
+                "elapsed_seconds",
+                "database_volume_bytes",
+            ]
+        )
+
+
+def _append_csv_row(path: Path, experiment_name: str | None, run_id: int, service_name: str,
+                    stage: str, stage_status: str | None, completed: Any, total: Any,
+                    throughput: Any, elapsed_seconds: Any, database_volume_bytes: int | None) -> None:
+    """Append one sample to CSV."""
+    with path.open("a", newline="", encoding="utf-8") as csv_file:
+        writer = csv.writer(csv_file)
+        writer.writerow(
+            [
+                datetime.now(timezone.utc).isoformat(),
+                experiment_name,
+                run_id,
+                service_name,
+                stage,
+                stage_status,
+                completed,
+                total,
+                throughput,
+                elapsed_seconds,
+                database_volume_bytes,
+            ]
+        )
+
+
+def _build_default_output_path() -> Path:
+    """Build shared default output location for multi-run comparisons."""
+    return Path("tests") / "ingestion" / "results" / "ingestion_progress.csv"
+
+
+def _fetch_database_volume_bytes(conn: psycopg.Connection) -> int | None:
+    """Return current database size in bytes for coarse storage growth tracking."""
+    with conn.cursor() as cur:
+        cur.execute("SELECT pg_database_size(current_database())")
+        row = cur.fetchone()
+    if row is None:
+        return None
+    value = row[0]
+    if value is None:
+        return None
+    return int(value)
+
+
+def _monitor_run_progress(
+    run_id: int,
+    service_name: str,
+    output_path: Path,
+    experiment_name: str | None,
+    poll_interval: float,
+    timeout_seconds: float,
+) -> int:
+    """Poll run history and append stage progress rows until end or timeout."""
+    started = time.perf_counter()
+
+    with _open_db_connection() as conn:
+        while True:
+            rows = _fetch_run_rows(conn, run_id, service_name)
+            database_volume_bytes = _fetch_database_volume_bytes(conn)
+
+            ended = any(row.status in (RUN_ENDED, RUN_STOPPED) for row in rows)
+
+            for row in rows:
+                stage = START_STAGE_BY_STATUS.get(row.status)
+                if stage is None:
+                    continue
+
+                metadata = row.metadata or {}
+                stage_status = metadata.get("status")
+                completed = metadata.get("completed")
+                total = metadata.get("total")
+                throughput = metadata.get("throughput")
+                elapsed_seconds = metadata.get("elapsed_seconds")
+
+                _append_csv_row(
+                    output_path,
+                    experiment_name,
+                    run_id,
+                    service_name,
+                    stage,
+                    stage_status,
+                    completed,
+                    total,
+                    throughput,
+                    elapsed_seconds,
+                    database_volume_bytes,
+                )
+
+            if ended:
+                print(f"Run {run_id} ended. CSV written to {output_path}")
+                return 0
+
+            if time.perf_counter() - started > timeout_seconds:
+                print(f"Timed out after {timeout_seconds} seconds. Partial CSV at {output_path}")
+                return 2
+
+            time.sleep(poll_interval)
+
+
+def main() -> int:
+    """Entrypoint."""
+    parser = argparse.ArgumentParser(description="Monitor EKH ingestion run progress to CSV")
+    parser.add_argument("--service", default="tbs-policies", help="Source service, e.g. wikipedia|tbs-policies")
+    parser.add_argument("--api-base-url", default="http://localhost:8000", help="EKH API base URL")
+    parser.add_argument("--experiment-name", default=None, help="Optional experiment name for grouping/comparison")
+    parser.add_argument("--run-id", type=int, default=None, help="Optional run_id to use")
+    parser.add_argument("--poll-interval", type=float, default=2.0, help="Polling interval in seconds")
+    parser.add_argument("--timeout-seconds", type=float, default=7200.0, help="Stop after this many seconds")
+    parser.add_argument("--output-csv", default=None, help="Optional output CSV path")
+    args = parser.parse_args()
+
+    load_dotenv()
+
+    # Use the provided run_id or generate a (somewhat) random run_id. 
+    # This removes the need to handle searching for the correct run_id.
+    run_id = int(time.time()) & 0x7FFFFFFF
+
+    output_path = Path(args.output_csv) if args.output_csv else _build_default_output_path()
+
+    _prepare_csv(output_path)
+
+    try:
+        _start_run(args.api_base_url, args.service, run_id)
+        print(f"Started run for '{args.service}' with run_id={run_id}")
+    except URLError as exc:
+        print(f"Failed to start run: {exc}")
+        return 1
+
+    return _monitor_run_progress(
+        run_id=run_id,
+        service_name=args.service,
+        output_path=output_path,
+        experiment_name=args.experiment_name,
+        poll_interval=args.poll_interval,
+        timeout_seconds=args.timeout_seconds,
+    )
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/ingestion/monitor_ingestion_progress.py
+++ b/tests/ingestion/monitor_ingestion_progress.py
@@ -122,6 +122,13 @@ def _start_run(api_base_url: str, service: str, run_id: int) -> None:
         _ = response.read()
 
 
+def _stop_run(api_base_url: str, service: str) -> None:
+    """Call the stop endpoint to halt the current run."""
+    url = f"{api_base_url.rstrip('/')}/knowledge/{service}/stop"
+    with urlopen(url, timeout=30) as response:  # nosec B310
+        _ = response.read()
+
+
 def _prepare_csv(path: Path) -> None:
     """Create CSV parent directory and write header if missing."""
     path.parent.mkdir(parents=True, exist_ok=True)
@@ -231,6 +238,7 @@ def _monitor_run_progress(
     experiment_name: str | None,
     poll_interval: float,
     timeout_seconds: float,
+    api_base_url: str,
 ) -> int:
     """Poll run history and append stage progress rows until end or timeout."""
     started = time.perf_counter()
@@ -254,7 +262,12 @@ def _monitor_run_progress(
                 return 0
 
             if time.perf_counter() - started > timeout_seconds:
-                print(f"Timed out after {timeout_seconds} seconds. Partial CSV at {output_path}")
+                print(f"Timed out after {timeout_seconds} seconds. Sending stop signal...")
+                try:
+                    _stop_run(api_base_url, service_name)
+                except URLError as exc:
+                    print(f"Failed to send stop signal: {exc}")
+                print(f"Partial CSV at {output_path}")
                 return 2
 
             time.sleep(poll_interval)
@@ -296,6 +309,7 @@ def main() -> int:
         experiment_name=args.experiment_name,
         poll_interval=args.poll_interval,
         timeout_seconds=args.timeout_seconds,
+        api_base_url=args.api_base_url,
     )
 
 


### PR DESCRIPTION
Closes #175 

This PR adds performance measurements to the `knowledge` service that periodically measures:
- Completed tasks (pages/records that are processed/ingested/stored)
- Throughput (amount of tasks being completed per second)

These metrics are stored to the run_history/status table. There is also a testing script called `monitor_ingestion_progress.py` that creates a log of these metrics over time, as well as the database volume. (This script currently assumes the database is Postgres). 
This log is outputted as a .csv file with each row being a timestamp, multiple tests can be done one after the other outputting to the same .csv.

Here is an example tests. The only difference between the two runs is I replaced the index type (IVFFLat vs HNSW).
<img width="1010" height="568" alt="image" src="https://github.com/user-attachments/assets/bc0414d6-f0a4-425c-995e-39986b3396af" />
<img width="1001" height="568" alt="image" src="https://github.com/user-attachments/assets/c9d82d9e-1054-450f-a9e5-b06a7399f134" />

### Usage:
- Modify your .env file to include the three variables in .env.example: 
```
SVC_KB_PROGRESS_METRICS_ENABLED=True # defaults to False; updates metadata on phase start rows while running
SVC_KB_PROGRESS_UPDATE_EVERY_N_ITEMS=500 # defaults to 500; update progress after this many newly completed items
SVC_KB_PROGRESS_UPDATE_EVERY_SECONDS=2.0 # defaults to 2.0; update progress at least this often
```
- After starting backend services (postgres, pgadmin, rabbitmq) as well as the main EKH service
- Run a command like this in another terminal window:
```
    uv run --env-file .env python tests/ingestion/monitor_ingestion_progress.py \
        --service tbs-policies \
        --api-base-url http://localhost:8000 \
        --poll-interval 2.0 \
        --timeout-seconds 7200
```
- Navigate to `http://localhost:8000/frontend/status` to view live metadata (This will be visible during CRON jobs as well if the environment variables are set)
- The output file will be by default: `tests/ingestion/results/ingestion_progress.csv` and it will update live throughout the run
A list of input arguments is displayed by typing:
`uv run --env-file .env python tests/ingestion/monitor_ingestion_progress.py --help`

For the above example experiment I set timeout-seconds to 900 (15 minutes), and set the `--experiment-name` to 'HNSW" and "IVFLLat"

### Some decisions made while implementing:
- time.perf_time is used instead of wall clock time to track performance
- Currently status/metrics are being stored with Run History, I decided to place it here because:
    - Allows for easier handling by future frontend/dashboard for EKH (uses the existing API endpoints)
    - Simpler implementation (placing in its own table would require changing the routing and database tables)
- Some state variables were added to the `knowledge` service to keep track of running time and last updated time
- This PR does not include warming up the table, as I didn't want to add any manual warmups that create and delete database entries from production code (an accidental prod database wipe would be, not fun) and the `pg_prewarm` functionality requires a separate extension.

### Considerations for future tickets
- After metrics for querying the database is included, we should consider separating metrics from status (mostly just to improve code quality)
- My tests above were small (I will likely need to do a longer one over night) but appear to confirm our initial hunches about IVFFLat vs HNSW (IVFFLat is better for storage throughput and database volume)
- Charts were made in a separate notebook, this is probably something to include in the future EKH Frontend/Dashboard.